### PR TITLE
Add step-by-step instructions for how to set up the server.

### DIFF
--- a/README-eisop.txt
+++ b/README-eisop.txt
@@ -1,0 +1,18 @@
+Some notes on setting up the RHEL 7 VM:
+
+- Clone the repository into /var/www/checkerweb
+- In the clone, run deploy-checkerweb.sh
+- sudo yum install mod_wsgi
+- Edit /etc/httpd/conf.modules.d/00-base.conf and add:
+
+LoadModule macro_module modules/mod_macro.so
+
+- In /etc/httpd/conf.d do:
+
+ln -s /var/www/checkerweb/wsgi-scripts/checkerweb-wsgi.conf .
+
+- Restart Apache:
+
+sudo apachectl restart
+
+TODO: Move Ubuntu instructions from wsgi-scripts to here


### PR DESCRIPTION
Charles, can you move the various Ubuntu instructions to this file?
Also, /var/www/checkerweb/wsgi-scripts/checkerweb-wsgi.conf contains a system-dependent user configuration, which should be noted somewhere.